### PR TITLE
fix: NIDM-Results query for peak coordinates

### DIFF
--- a/results/f9d1d5b2-800d-11e5-8dce-2b8a41eccd30.json
+++ b/results/f9d1d5b2-800d-11e5-8dce-2b8a41eccd30.json
@@ -7,23 +7,31 @@
         "sparql": ["PREFIX nidm: <http://purl.org/nidash/nidm#>",
                    "PREFIX prov: <http://www.w3.org/ns/prov#>",
                    "prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>",
-                   "SELECT DISTINCT ?statmap ?statmap_filename ?statmap_location ?statmap_type ?z_score ?pvalue_uncorrected ?coord_name ?coordinate",
-                   "WHERE {?statmap #nidm:NIDM_0000123 obo:STATO_0000176 ; # t-statistic",
-                   "#nidm:NIDM_0000123 obo:STATO_0000376 ; #z-statistic",
-                   "nidm:NIDM_0000123 ?statmap_type ;",
+                   "prefix spm: <http://purl.org/nidash/spm#>"
+                   "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>"
+                   "prefix peak: <http://purl.org/nidash/nidm#NIDM_0000062>"
+                   "prefix significant_cluster: <http://purl.org/nidash/nidm#NIDM_0000070>"
+                   "prefix coordinate: <http://purl.org/nidash/nidm#NIDM_0000086>"
+                   "prefix equivalent_zstatistic: <http://purl.org/nidash/nidm#NIDM_0000092>"
+                   "prefix pvalue_fwer: <http://purl.org/nidash/nidm#NIDM_0000115>"
+                   "prefix pvalue_uncorrected: <http://purl.org/nidash/nidm#NIDM_0000116>"
+                   "prefix statistic_map: <http://purl.org/nidash/nidm#NIDM_0000076>"
+                   "prefix statistic_type: <http://purl.org/nidash/nidm#NIDM_0000123>"
+                   "SELECT DISTINCT ?statmap ?statmap_location ?statmap_type ?z_score ?pvalue_uncorrected ?coord_name ?coordinate",
+                   "WHERE {
+                    statistic_type: ?statmap_type ;",
                    "prov:atLocation ?statmap_location ;",
-                   "nfo:fileName ?statmap_filename .",
                    "?inference prov:used ?statmap .",
                    "?excursion_set_map prov:wasGeneratedBy ?inference .",
                    "?sig_cluster prov:wasDerivedFrom ?excusion_set_map .",
                    "?peak prov:wasDerivedFrom ?sig_cluster ;",
                    "prov:atLocation ?coord ;",
-                   "nidm:NIDM_0000092 ?z_score ;",
+                   "equivalent_zstatistic: ?z_score ;",
                    "rdfs:label ?peak_name ;",
-                   "nidm:NIDM_0000116 ?pvalue_uncorrected .",
-                   "?coord a nidm:NIDM_0000015 ;",
-                   "rdfs:label ?coord_name ;",
-                   "nidm:NIDM_0000086 ?coordinate .",
+                   "pvalue_uncorrected: ?pvalue_uncorrected .",
+                   "?peak prov:atLocation ?coordinate_id ."
+                   "coordinate_id rdfs:label ?coord_name ;",
+                   "coordinate: ?coordinate .",
                    "}"],
         "reference": "https://github.com/NeuroVault/NeuroVault/pull/354#issuecomment-151973717",
         "@context":""   


### PR DESCRIPTION
Hi @nicholsn, @vsoch,

Following discussions at https://github.com/NeuroVault/NeuroVault/pull/354#issuecomment-152852641, this PR fixes the NIDM-Results query to get peak coordinates (very similar to [peak.rq](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm-results/query/peak.rq)). 

> we see two issues here :  one is the the same statmap file location (for example, ZStatistic003.nii.gz in the right column at the way top) is associated with two file names (zstat3 and Zstatistic_T003.nii.gz)  I'm not sure if the second is a Z or a T map because it has both names. 

The filename is not guaranteed to be unique. With an FSL export (such as this one) you will have two filenames for each Z-map. The first one is the one used by FSL (e.g. `zstat1.nii.gz`), the second one is the one generated by the export (e.g. `Zstatistic_T001.nii.gz`). 

I have removed this variable from the query, as I don't think you need it for the viewer? Or do you?  

> The second issue, is obviously that we have the same coordinate for every single map. 

This is odd... There might be an issue with the turtle document. I have just run this locally on [fsl_nidm.ttl](https://github.com/incf-nidash/nidm/blob/master/nidm/nidm/nidm-results/fsl/example001/fsl_nidm.ttl) and I don't have this issue. Let me know if you still have it after updating the query. 
